### PR TITLE
Feature/collecte de plusieurs annees pour le dataset edc

### DIFF
--- a/analytics/notebooks/exemple.ipynb
+++ b/analytics/notebooks/exemple.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Exemple de notebook - premières analyses des données SISE-Eaux\n"
+    "# Exemple de notebook - premières analyses des données EDC (Eau Distribuée par Commune)\n"
    ]
   },
   {
@@ -197,7 +197,7 @@
    "source": [
     "# Affichons les tables\n",
     "\n",
-    "con.table(\"sise_communes\").df()"
+    "con.table(\"edc_communes\").df()"
    ]
   },
   {
@@ -584,7 +584,7 @@
     }
    ],
    "source": [
-    "con.table(\"sise_prelevements\").df()"
+    "con.table(\"edc_prelevements\").df()"
    ]
   },
   {
@@ -1155,7 +1155,7 @@
     }
    ],
    "source": [
-    "con.table(\"sise_resultats\").df().head(20)"
+    "con.table(\"edc_resultats\").df().head(20)"
    ]
   },
   {
@@ -1172,9 +1172,9 @@
     }
    ],
    "source": [
-    "# Chargeons la table sise_communes dans un pandas dataframe, et calculons le nombre de communes\n",
+    "# Chargeons la table edc_communes dans un pandas dataframe, et calculons le nombre de communes\n",
     "\n",
-    "communes = con.table(\"sise_communes\").to_df()\n",
+    "communes = con.table(\"edc_communes\").to_df()\n",
     "nombre_de_communes = communes.nunique()[\"inseecommune\"]\n",
     "print(f\"nombre_de_communes = {nombre_de_communes}\")"
    ]
@@ -1228,7 +1228,7 @@
     "\n",
     "con.sql(\"\"\"\n",
     "    SELECT libmajparametre, COUNT(*) as count\n",
-    "    FROM sise_resultats\n",
+    "    FROM edc_resultats\n",
     "    GROUP BY libmajparametre\n",
     "    ORDER BY count DESC\n",
     "\"\"\").show()"
@@ -1361,7 +1361,7 @@
     "\n",
     "# ...et faisons la même requête SQL en utilisant l'extension SQL pour Jupyter\n",
     "\n",
-    "%sql SELECT libmajparametre, COUNT(*) as count FROM sise_resultats GROUP BY libmajparametre ORDER BY count DESC;"
+    "%sql SELECT libmajparametre, COUNT(*) as count FROM edc_resultats GROUP BY libmajparametre ORDER BY count DESC;"
    ]
   },
   {
@@ -1414,7 +1414,7 @@
     "\n",
     "con.sql(f\"\"\"\n",
     "    SELECT *\n",
-    "    FROM sise_prelevements\n",
+    "    FROM edc_prelevements\n",
     "    WHERE nomcommuneprinc = '{nomcommune}'\n",
     "\"\"\").show()"
    ]

--- a/pipelines/tasks/_common.py
+++ b/pipelines/tasks/_common.py
@@ -11,7 +11,7 @@ os.makedirs(CACHE_FOLDER, exist_ok=True)
 os.makedirs(DATABASE_FOLDER, exist_ok=True)
 
 
-def clear_cache(recreate_folder:bool=True):
+def clear_cache(recreate_folder: bool = True):
     """Clear the cache folder."""
     shutil.rmtree(CACHE_FOLDER)
     if recreate_folder:

--- a/pipelines/tasks/_common.py
+++ b/pipelines/tasks/_common.py
@@ -11,6 +11,8 @@ os.makedirs(CACHE_FOLDER, exist_ok=True)
 os.makedirs(DATABASE_FOLDER, exist_ok=True)
 
 
-def clear_cache():
+def clear_cache(recreate_folder:bool=True):
     """Clear the cache folder."""
     shutil.rmtree(CACHE_FOLDER)
+    if recreate_folder:
+        os.makedirs(CACHE_FOLDER, exist_ok=True)

--- a/pipelines/tasks/_config_edc.py
+++ b/pipelines/tasks/_config_edc.py
@@ -1,0 +1,103 @@
+from typing import Dict
+
+
+def get_edc_config() -> Dict:
+    """
+    Returns various configuration for processing the EDC (Eau distribuée par commune) datasets.
+    The data comes from https://www.data.gouv.fr/fr/datasets/resultats-du-controle-sanitaire-de-leau-distribuee-commune-par-commune/
+    For each year a dataset is downloadable on a URL like this (ex. 2024):
+        https://www.data.gouv.fr/fr/datasets/r/84a67a3b-08a7-4001-98e6-231c74a98139
+    :return: A dict with the config used for processing.
+        The "source" part is related to the data.gouv datasource
+        The "files" part is related to the extracted files information and sql table names
+    """
+
+    edc_config = {
+        "source": {
+            "base_url": "https://www.data.gouv.fr/fr/datasets/r/",
+            "available_years": [
+                "2016",
+                "2017",
+                "2018",
+                "2019",
+                "2020",
+                "2021",
+                "2022",
+                "2023",
+                "2024",
+            ],
+            "yearly_files_infos": {
+                "2024": {
+                    "id": "84a67a3b-08a7-4001-98e6-231c74a98139",
+                    "zipfile": "dis-2024.zip",
+                },
+                "2023": {
+                    "id": "c89dec4a-d985-447c-a102-75ba814c398e",
+                    "zipfile": "dis-2023.zip",
+                },
+                "2022": {
+                    "id": "a97b6074-c4dd-4ef2-8922-b0cf04dbff9a",
+                    "zipfile": "dis-2022.zip",
+                },
+                "2021": {
+                    "id": "d2b432cc-3761-44d3-8e66-48bc15300bb5",
+                    "zipfile": "dis-2021.zip",
+                },
+                "2020": {
+                    "id": "a6cb4fea-ef8c-47a5-acb3-14e49ccad801",
+                    "zipfile": "dis-2020.zip",
+                },
+                "2019": {
+                    "id": "861f2a7d-024c-4bf0-968b-9e3069d9de07",
+                    "zipfile": "dis-2019.zip",
+                },
+                "2018": {
+                    "id": "0513b3c0-dc18-468d-a969-b3508f079792",
+                    "zipfile": "dis-2018.zip",
+                },
+                "2017": {
+                    "id": "5785427b-3167-49fa-a581-aef835f0fb04",
+                    "zipfile": "dis-2017.zip",
+                },
+                "2016": {
+                    "id": "483c84dd-7912-483b-b96f-4fa5e1d8651f",
+                    "zipfile": "dis-2016.zip",
+                },
+            },
+        },
+        "files": {
+            "communes": {
+                "file_name_prefix": "DIS_COM_UDI_",
+                "file_extension": ".txt",
+                "table_name": "edc_communes",
+            },
+            "prelevements": {
+                "file_name_prefix": "DIS_PLV_",
+                "file_extension": ".txt",
+                "table_name": "edc_prelevements",
+            },
+            "resultats": {
+                "file_name_prefix": "DIS_RESULT_",
+                "file_extension": ".txt",
+                "table_name": "edc_resultats",
+            },
+        },
+    }
+
+    return edc_config
+
+
+def create_edc_yearly_filename(
+    file_name_prefix: str, file_extension: str, year: str
+) -> str:
+    """
+    This function is used to recreate the yearly filenames of the extracted files.
+    It is intended for use with the edc_config["files"] data above.
+    For example in 2024 the file name for communes should be:
+        DIS_COM_UDI_2024.txt
+    :param file_name_prefix: prefix of the filename
+    :param file_extension: extension of the file
+    :param year: year of the needed file
+    :return: the yearly filename as a string
+    """
+    return file_name_prefix + year + file_extension

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -62,7 +62,7 @@ def download_extract_insert_yearly_edc_data(year: str):
     extracts the files and insert the data into duckdb
     :param year: The year from which we want to download the dataset
     :return: Create or replace the associated tables in the duckcb database.
-        It adds the column "annee_prelevement" based on year as an integer.
+        It adds the column "de_partition" based on year as an integer.
     """
 
     yearly_dataset_info = get_yearly_edc_infos(year=year)
@@ -112,7 +112,7 @@ def download_extract_insert_yearly_edc_data(year: str):
         if check_table_existence(conn=conn, table_name=f"{file_info['table_name']}"):
             query = f"""
                 DELETE FROM {f"{file_info['table_name']}"}
-                WHERE annee_prelevement = CAST({year} as INTEGER)
+                WHERE de_partition = CAST({year} as INTEGER)
                 ;
             """
             conn.execute(query)
@@ -124,7 +124,7 @@ def download_extract_insert_yearly_edc_data(year: str):
         query_select = f"""
             SELECT 
                 *,
-                CAST({year} as INTEGER) AS annee_prelevement
+                CAST({year} as INTEGER) AS de_partition
             FROM read_csv('{filepath}', header=true, delim=',');
         """
 

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -165,7 +165,7 @@ def process_sise_eaux_dataset(
     if refresh_type == "all":
         years_to_update = available_years
     elif refresh_type == "last":
-        years_to_update = available_years[-1]
+        years_to_update = available_years[-1:]
     elif refresh_type == "custom":
         if custom_years:
             years_to_update = list(set(custom_years).intersection(available_years))

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -107,7 +107,7 @@ def download_extract_insert_yearly_edc_data(year: str):
 
 
 def process_edc_datasets(
-    refresh_type: Literal["all", "last", "custom"] = "all",
+    refresh_type: Literal["all", "last", "custom"] = "last",
     custom_years: List[str] = None,
 ):
     """

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -174,6 +174,10 @@ def process_edc_datasets(
             raise ValueError(
                 """ custom_years parameter needs to be specified if refresh_type="custom" """
             )
+    else:
+        raise ValueError(
+            f""" refresh_type needs to be one of ["all", "last", "custom"], it can't be: {refresh_type}"""
+        )
 
     logger.info(
         f"Launching processing of EDC datasets for years: {years_to_update}"

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -73,17 +73,17 @@ def download_extract_insert_yearly_SISE_data(year: str):
         },
     }
 
-    logger.info(f"Downloading and extracting SISE-Eaux dataset for {year}...")
+    logger.info(f"Processing SISE-Eaux dataset for {year}...")
     response = requests.get(DATA_URL, stream=True)
     with open(ZIP_FILE, "wb") as f:
         for chunk in response.iter_content(chunk_size=8192):
             f.write(chunk)
 
-    logger.info("Extracting files...")
+    logger.info("   Extracting files...")
     with ZipFile(ZIP_FILE, "r") as zip_ref:
         zip_ref.extractall(EXTRACT_FOLDER)
 
-    logger.info("Creating tables in the database...")
+    logger.info("   Creating or updating tables in the database...")
     conn = duckdb.connect(DUCKDB_FILE)
 
     for file_info in FILES.values():
@@ -115,7 +115,7 @@ def download_extract_insert_yearly_SISE_data(year: str):
 
     conn.close()
 
-    logger.info("Cleaning up...")
+    logger.info("   Cleaning up cache...")
     clear_cache()
 
     return True
@@ -174,9 +174,15 @@ def process_sise_eaux_dataset(
                 """ custom_years parameter needs to be specified if refresh_type="custom" """
             )
 
+    logger.info(
+        f"Launching processing of SISE-Eaux dataset for years: {years_to_update}"
+    )
+
     for year in years_to_update:
         download_extract_insert_yearly_SISE_data(year=year)
 
+    logger.info("Cleaning up cache...")
+    clear_cache(recreate_folder=False)
     return True
 
 

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -83,5 +83,15 @@ def process_sise_eaux_dataset_2024(year:str):
     return True
 
 
+def check_table_existence(conn, table_name):
+    query = f"""
+        SELECT COUNT(*)
+        FROM information_schema.tables
+        WHERE table_name = '{table_name}'
+        """
+    conn.execute(query)
+    return list(conn.fetchone())[0] == 1
+
+
 def execute():
     process_sise_eaux_dataset_2024(year="2024")

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -4,15 +4,17 @@ Consolidate data into the database.
 
 import logging
 import os
-from typing import Dict, List, Literal
+from typing import List, Literal
 from zipfile import ZipFile
 
 import duckdb
 import requests
 
 from ._common import CACHE_FOLDER, DUCKDB_FILE, clear_cache
+from ._config_edc import get_edc_config, create_edc_yearly_filename
 
 logger = logging.getLogger(__name__)
+edc_config = get_edc_config()
 
 
 def check_table_existence(conn: duckdb.DuckDBPyConnection, table_name: str) -> bool:
@@ -31,31 +33,6 @@ def check_table_existence(conn: duckdb.DuckDBPyConnection, table_name: str) -> b
     return list(conn.fetchone())[0] == 1
 
 
-def get_yearly_edc_infos(year: str) -> Dict[str, str]:
-    """
-    Returns information for yearly dataset extract of the EDC (Eau distribuée par commune) datasets.
-    The data comes from https://www.data.gouv.fr/fr/datasets/resultats-du-controle-sanitaire-de-leau-distribuee-commune-par-commune/
-    For each year a dataset is downloadable on a URL like this (ex. 2024):
-        https://www.data.gouv.fr/fr/datasets/r/84a67a3b-08a7-4001-98e6-231c74a98139
-    The id of the dataset is the last part of this URL
-    The name of the dataset is dis-YEAR.zip (but the format could potentially change).
-    :param year: The year from which we want to get the dataset information.
-    :return: A dict with the id and name of the dataset.
-    """
-    edc_dis_files_info_by_year = {
-        "2024": {"id": "84a67a3b-08a7-4001-98e6-231c74a98139", "name": "dis-2024.zip"},
-        "2023": {"id": "c89dec4a-d985-447c-a102-75ba814c398e", "name": "dis-2023.zip"},
-        "2022": {"id": "a97b6074-c4dd-4ef2-8922-b0cf04dbff9a", "name": "dis-2022.zip"},
-        "2021": {"id": "d2b432cc-3761-44d3-8e66-48bc15300bb5", "name": "dis-2021.zip"},
-        "2020": {"id": "a6cb4fea-ef8c-47a5-acb3-14e49ccad801", "name": "dis-2020.zip"},
-        "2019": {"id": "861f2a7d-024c-4bf0-968b-9e3069d9de07", "name": "dis-2019.zip"},
-        "2018": {"id": "0513b3c0-dc18-468d-a969-b3508f079792", "name": "dis-2018.zip"},
-        "2017": {"id": "5785427b-3167-49fa-a581-aef835f0fb04", "name": "dis-2017.zip"},
-        "2016": {"id": "483c84dd-7912-483b-b96f-4fa5e1d8651f", "name": "dis-2016.zip"},
-    }
-    return edc_dis_files_info_by_year[year]
-
-
 def download_extract_insert_yearly_edc_data(year: str):
     """
     Downloads from www.data.gouv.fr the EDC (Eau distribuée par commune) dataset for one year,
@@ -65,30 +42,16 @@ def download_extract_insert_yearly_edc_data(year: str):
         It adds the column "de_partition" based on year as an integer.
     """
 
-    yearly_dataset_info = get_yearly_edc_infos(year=year)
-
     # Dataset specific constants
-    DATA_URL = f"https://www.data.gouv.fr/fr/datasets/r/{yearly_dataset_info['id']}"
-    ZIP_FILE = os.path.join(CACHE_FOLDER, yearly_dataset_info["name"])
+    DATA_URL = (
+        edc_config["source"]["base_url"]
+        + edc_config["source"]["yearly_files_infos"][year]["id"]
+    )
+    ZIP_FILE = os.path.join(
+        CACHE_FOLDER, edc_config["source"]["yearly_files_infos"][year]["zipfile"]
+    )
     EXTRACT_FOLDER = os.path.join(CACHE_FOLDER, f"raw_data_{year}")
-
-    FILES = {
-        "communes": {
-            "filename_prefix": f"DIS_COM_UDI_",
-            "file_extension": ".txt",
-            "table_name": f"edc_communes",
-        },
-        "prelevements": {
-            "filename_prefix": f"DIS_PLV_",
-            "file_extension": ".txt",
-            "table_name": f"edc_prelevements",
-        },
-        "resultats": {
-            "filename_prefix": f"DIS_RESULT_",
-            "file_extension": ".txt",
-            "table_name": f"edc_resultats",
-        },
-    }
+    FILES = edc_config["files"]
 
     logger.info(f"Processing EDC dataset for {year}...")
     response = requests.get(DATA_URL, stream=True)
@@ -106,7 +69,11 @@ def download_extract_insert_yearly_edc_data(year: str):
     for file_info in FILES.values():
         filepath = os.path.join(
             EXTRACT_FOLDER,
-            f"{file_info['filename_prefix']}{year}{file_info['file_extension']}",
+            create_edc_yearly_filename(
+                file_name_prefix=file_info["file_name_prefix"],
+                file_extension=file_info["file_extension"],
+                year=year,
+            ),
         )
 
         if check_table_existence(conn=conn, table_name=f"{file_info['table_name']}"):
@@ -151,17 +118,7 @@ def process_edc_datasets(
     :param custom_years: years to update
     :return:
     """
-    available_years = [
-        "2016",
-        "2017",
-        "2018",
-        "2019",
-        "2020",
-        "2021",
-        "2022",
-        "2023",
-        "2024",
-    ]
+    available_years = edc_config["source"]["available_years"]
 
     if refresh_type == "all":
         years_to_update = available_years

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -39,23 +39,24 @@ def get_yearly_dataset_infos(year:str) -> Dict[str,str]:
     return dis_files_info_by_year[year]
 
 
-def process_sise_eaux_dataset_2024():
+def process_sise_eaux_dataset_2024(year:str):
     """Process SISE-Eaux dataset for 2024."""
 
+    yearly_dataset_info = get_yearly_dataset_infos(year = year)
     # Dataset specific constants
     DATA_URL = (
-        "https://www.data.gouv.fr/fr/datasets/r/84a67a3b-08a7-4001-98e6-231c74a98139"
+        f"https://www.data.gouv.fr/fr/datasets/r/{yearly_dataset_info["id"]}"
     )
-    ZIP_FILE = os.path.join(CACHE_FOLDER, "dis-2024.zip")
-    EXTRACT_FOLDER = os.path.join(CACHE_FOLDER, "raw_data_2024")
+    ZIP_FILE = os.path.join(CACHE_FOLDER, yearly_dataset_info["name"])
+    EXTRACT_FOLDER = os.path.join(CACHE_FOLDER, f"raw_data_{year}")
 
     FILES = {
-        "communes": {"filename": "DIS_COM_UDI_2024.txt", "table": "sise_communes"},
-        "prelevements": {"filename": "DIS_PLV_2024.txt", "table": "sise_prelevements"},
-        "resultats": {"filename": "DIS_RESULT_2024.txt", "table": "sise_resultats"},
+        "communes": {"filename": f"DIS_COM_UDI_{year}.txt", "table": f"sise_communes_{year}"},
+        "prelevements": {"filename": f"DIS_PLV_{year}.txt", "table": f"sise_prelevements_{year}"},
+        "resultats": {"filename": f"DIS_RESULT_{year}.txt", "table": f"sise_resultats_{year}"},
     }
 
-    logger.info("Downloading and extracting SISE-Eaux dataset for 2024...")
+    logger.info(f"Downloading and extracting SISE-Eaux dataset for {year}...")
     response = requests.get(DATA_URL, stream=True)
     with open(ZIP_FILE, "wb") as f:
         for chunk in response.iter_content(chunk_size=8192):
@@ -83,4 +84,4 @@ def process_sise_eaux_dataset_2024():
 
 
 def execute():
-    process_sise_eaux_dataset_2024()
+    process_sise_eaux_dataset_2024(year="2024")

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -91,7 +91,8 @@ def download_extract_insert_yearly_edc_data(year: str):
         query_select = f"""
             SELECT 
                 *,
-                CAST({year} as INTEGER) AS de_partition
+                CAST({year} AS INTEGER) AS de_partition,
+                current_date            AS de_ingestion_date
             FROM read_csv('{filepath}', header=true, delim=',');
         """
 

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -191,5 +191,3 @@ def process_edc_datasets(
 
 def execute():
     process_edc_datasets()
-
-    conn = duckdb.connect(DUCKDB_FILE)

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -15,6 +15,22 @@ from ._common import CACHE_FOLDER, DUCKDB_FILE, clear_cache
 logger = logging.getLogger(__name__)
 
 
+def check_table_existence(conn: duckdb.DuckDBPyConnection, table_name: str) -> bool:
+    """
+    Check if a table exists in the duckdb database
+    :param conn: The duckdb connection to use
+    :param table_name: The table name to check existence
+    :return: True if the table exists, False if not
+    """
+    query = f"""
+        SELECT COUNT(*)
+        FROM information_schema.tables
+        WHERE table_name = '{table_name}'
+        """
+    conn.execute(query)
+    return list(conn.fetchone())[0] == 1
+
+
 def get_yearly_dataset_infos(year: str) -> Dict[str, str]:
     """
     Returns information for yearly dataset extract of the SISE Eaux datasets.
@@ -119,22 +135,6 @@ def download_extract_insert_yearly_SISE_data(year: str):
     clear_cache()
 
     return True
-
-
-def check_table_existence(conn: duckdb.DuckDBPyConnection, table_name: str) -> bool:
-    """
-    Check if a table exists in the duckdb database
-    :param conn: The duckdb connection to use
-    :param table_name: The table name to check existence
-    :return: True if the table exists, False if not
-    """
-    query = f"""
-        SELECT COUNT(*)
-        FROM information_schema.tables
-        WHERE table_name = '{table_name}'
-        """
-    conn.execute(query)
-    return list(conn.fetchone())[0] == 1
 
 
 def process_sise_eaux_dataset(

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -179,9 +179,7 @@ def process_edc_datasets(
             f""" refresh_type needs to be one of ["all", "last", "custom"], it can't be: {refresh_type}"""
         )
 
-    logger.info(
-        f"Launching processing of EDC datasets for years: {years_to_update}"
-    )
+    logger.info(f"Launching processing of EDC datasets for years: {years_to_update}")
 
     for year in years_to_update:
         download_extract_insert_yearly_edc_data(year=year)

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -4,6 +4,7 @@ Consolidate data into the database.
 
 import logging
 import os
+from typing import Dict
 from zipfile import ZipFile
 
 import duckdb
@@ -12,6 +13,30 @@ import requests
 from ._common import CACHE_FOLDER, DUCKDB_FILE, clear_cache
 
 logger = logging.getLogger(__name__)
+
+def get_yearly_dataset_infos(year:str) -> Dict[str,str]:
+    """
+    Returns information for yearly dataset extract of the SISE Eaux datasets.
+    The data comes from https://www.data.gouv.fr/fr/datasets/resultats-du-controle-sanitaire-de-leau-distribuee-commune-par-commune/
+    For each year a dataset is downloadable on a URL like this (ex. 2024):
+        https://www.data.gouv.fr/fr/datasets/r/84a67a3b-08a7-4001-98e6-231c74a98139
+    The id of the dataset is the last part of this URL
+    The name of the dataset is dis-YEAR.zip (but the format could potentially change).
+    :param year: The year from which we want to get the dataset information.
+    :return: A dict with the id and name of the dataset.
+    """
+    dis_files_info_by_year = {
+        "2024": {"id": "84a67a3b-08a7-4001-98e6-231c74a98139", "name" : "dis-2024.zip"},
+        "2023": {"id":"c89dec4a-d985-447c-a102-75ba814c398e", "name" : "dis-2023.zip"},
+        "2022": {"id":"a97b6074-c4dd-4ef2-8922-b0cf04dbff9a", "name" : "dis-2022.zip"},
+        "2021": {"id":"d2b432cc-3761-44d3-8e66-48bc15300bb5", "name" : "dis-2021.zip"},
+        "2020": {"id":"a6cb4fea-ef8c-47a5-acb3-14e49ccad801", "name" : "dis-2020.zip"},
+        "2019": {"id":"861f2a7d-024c-4bf0-968b-9e3069d9de07", "name" : "dis-2019.zip"},
+        "2018": {"id":"0513b3c0-dc18-468d-a969-b3508f079792", "name" : "dis-2018.zip"},
+        "2017": {"id":"5785427b-3167-49fa-a581-aef835f0fb04", "name" : "dis-2017.zip"},
+        "2016": {"id":"483c84dd-7912-483b-b96f-4fa5e1d8651f", "name" : "dis-2016.zip"}
+    }
+    return dis_files_info_by_year[year]
 
 
 def process_sise_eaux_dataset_2024():

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -4,7 +4,7 @@ Consolidate data into the database.
 
 import logging
 import os
-from typing import Dict
+from typing import Dict, List, Literal
 from zipfile import ZipFile
 
 import duckdb
@@ -14,7 +14,8 @@ from ._common import CACHE_FOLDER, DUCKDB_FILE, clear_cache
 
 logger = logging.getLogger(__name__)
 
-def get_yearly_dataset_infos(year:str) -> Dict[str,str]:
+
+def get_yearly_dataset_infos(year: str) -> Dict[str, str]:
     """
     Returns information for yearly dataset extract of the SISE Eaux datasets.
     The data comes from https://www.data.gouv.fr/fr/datasets/resultats-du-controle-sanitaire-de-leau-distribuee-commune-par-commune/
@@ -26,15 +27,15 @@ def get_yearly_dataset_infos(year:str) -> Dict[str,str]:
     :return: A dict with the id and name of the dataset.
     """
     dis_files_info_by_year = {
-        "2024": {"id": "84a67a3b-08a7-4001-98e6-231c74a98139", "name" : "dis-2024.zip"},
-        "2023": {"id":"c89dec4a-d985-447c-a102-75ba814c398e", "name" : "dis-2023.zip"},
-        "2022": {"id":"a97b6074-c4dd-4ef2-8922-b0cf04dbff9a", "name" : "dis-2022.zip"},
-        "2021": {"id":"d2b432cc-3761-44d3-8e66-48bc15300bb5", "name" : "dis-2021.zip"},
-        "2020": {"id":"a6cb4fea-ef8c-47a5-acb3-14e49ccad801", "name" : "dis-2020.zip"},
-        "2019": {"id":"861f2a7d-024c-4bf0-968b-9e3069d9de07", "name" : "dis-2019.zip"},
-        "2018": {"id":"0513b3c0-dc18-468d-a969-b3508f079792", "name" : "dis-2018.zip"},
-        "2017": {"id":"5785427b-3167-49fa-a581-aef835f0fb04", "name" : "dis-2017.zip"},
-        "2016": {"id":"483c84dd-7912-483b-b96f-4fa5e1d8651f", "name" : "dis-2016.zip"}
+        "2024": {"id": "84a67a3b-08a7-4001-98e6-231c74a98139", "name": "dis-2024.zip"},
+        "2023": {"id": "c89dec4a-d985-447c-a102-75ba814c398e", "name": "dis-2023.zip"},
+        "2022": {"id": "a97b6074-c4dd-4ef2-8922-b0cf04dbff9a", "name": "dis-2022.zip"},
+        "2021": {"id": "d2b432cc-3761-44d3-8e66-48bc15300bb5", "name": "dis-2021.zip"},
+        "2020": {"id": "a6cb4fea-ef8c-47a5-acb3-14e49ccad801", "name": "dis-2020.zip"},
+        "2019": {"id": "861f2a7d-024c-4bf0-968b-9e3069d9de07", "name": "dis-2019.zip"},
+        "2018": {"id": "0513b3c0-dc18-468d-a969-b3508f079792", "name": "dis-2018.zip"},
+        "2017": {"id": "5785427b-3167-49fa-a581-aef835f0fb04", "name": "dis-2017.zip"},
+        "2016": {"id": "483c84dd-7912-483b-b96f-4fa5e1d8651f", "name": "dis-2016.zip"},
     }
     return dis_files_info_by_year[year]
 
@@ -120,7 +121,13 @@ def download_extract_insert_yearly_SISE_data(year: str):
     return True
 
 
-def check_table_existence(conn, table_name):
+def check_table_existence(conn: duckdb.DuckDBPyConnection, table_name: str) -> bool:
+    """
+    Check if a table exists in the duckdb database
+    :param conn: The duckdb connection to use
+    :param table_name: The table name to check existence
+    :return: True if the table exists, False if not
+    """
     query = f"""
         SELECT COUNT(*)
         FROM information_schema.tables
@@ -174,4 +181,4 @@ def process_sise_eaux_dataset(
 
 
 def execute():
-    process_sise_eaux_dataset_2024(year="2024")
+    process_sise_eaux_dataset()


### PR DESCRIPTION
## Context

The original code was getting data only for the 2024 year, the goal is to get data from 2016 to 2024 and parametrize the year. 

## Changes

### build_database.py
- Récupération des données liés aux datasets annuels (via l'url on obtient l'id et le name) dans la fonction `get_yearly_dataset_infos()`
-  Creation of a function `check_table_existence()` to check if a table exists in duckdb. 
- Parametrize `process_sise_eaux_dataset_2024()`  function (renamed to `download_extract_insert_yearly_SISE_data()`) in order to add a year parameter. 
To avoid duplicates I check if the table exists and if yes I insert data instead of create the table. 
- Adds `process_sise_eaux_dataset()` function as a controller of `download_extract_insert_yearly_SISE_data()` with _refresh_type_ parameter. 

### _common.py
- Recreates the cache folder as `shutil.rmtree` drops the folder and all its children. Sometimes we just want to empty the folder.

I will add explanations on the code below directly if needed.

## Results

I have run this for the years 2016 to 2024:
```shell
pascal:~/path_to_project/13_pollution_eau$ uv run pipelines/run.py run build_database
2025-02-03 01:26:34,327 - root - INFO - Starting task build_database...
2025-02-03 01:26:34,328 - tasks.build_database - INFO - Launching processing of SISE-Eaux dataset for years: ['2016', '2017', '2018', '2019', '2020', '2021', '2022', '2023', '2024']
2025-02-03 01:26:34,328 - tasks.build_database - INFO - Processing SISE-Eaux dataset for 2016...
2025-02-03 01:27:18,227 - tasks.build_database - INFO -    Extracting files...
2025-02-03 01:28:14,023 - tasks.build_database - INFO -    Creating or updating tables in the database...
2025-02-03 01:29:28,808 - tasks.build_database - INFO -    Cleaning up cache...
2025-02-03 01:29:29,981 - tasks.build_database - INFO - Processing SISE-Eaux dataset for 2017...
2025-02-03 01:30:17,229 - tasks.build_database - INFO -    Extracting files...
2025-02-03 01:31:12,358 - tasks.build_database - INFO -    Creating or updating tables in the database...
2025-02-03 01:32:48,811 - tasks.build_database - INFO -    Cleaning up cache...
2025-02-03 01:32:50,153 - tasks.build_database - INFO - Processing SISE-Eaux dataset for 2018...
2025-02-03 01:33:39,203 - tasks.build_database - INFO -    Extracting files...
2025-02-03 01:34:36,361 - tasks.build_database - INFO -    Creating or updating tables in the database...
2025-02-03 01:35:58,385 - tasks.build_database - INFO -    Cleaning up cache...
2025-02-03 01:35:59,584 - tasks.build_database - INFO - Processing SISE-Eaux dataset for 2019...
2025-02-03 01:36:57,496 - tasks.build_database - INFO -    Extracting files...
2025-02-03 01:37:53,370 - tasks.build_database - INFO -    Creating or updating tables in the database...
2025-02-03 01:39:07,474 - tasks.build_database - INFO -    Cleaning up cache...
2025-02-03 01:39:08,617 - tasks.build_database - INFO - Processing SISE-Eaux dataset for 2020...
2025-02-03 01:40:06,480 - tasks.build_database - INFO -    Extracting files...
2025-02-03 01:41:03,738 - tasks.build_database - INFO -    Creating or updating tables in the database...
2025-02-03 01:42:49,059 - tasks.build_database - INFO -    Cleaning up cache...
2025-02-03 01:42:50,637 - tasks.build_database - INFO - Processing SISE-Eaux dataset for 2021...
2025-02-03 01:43:50,716 - tasks.build_database - INFO -    Extracting files...
2025-02-03 01:44:54,239 - tasks.build_database - INFO -    Creating or updating tables in the database...
2025-02-03 01:46:13,206 - tasks.build_database - INFO -    Cleaning up cache...
2025-02-03 01:46:14,492 - tasks.build_database - INFO - Processing SISE-Eaux dataset for 2022...
2025-02-03 01:47:10,268 - tasks.build_database - INFO -    Extracting files...
2025-02-03 01:48:14,867 - tasks.build_database - INFO -    Creating or updating tables in the database...
2025-02-03 01:49:54,366 - tasks.build_database - INFO -    Cleaning up cache...
2025-02-03 01:49:55,577 - tasks.build_database - INFO - Processing SISE-Eaux dataset for 2023...
2025-02-03 01:50:47,723 - tasks.build_database - INFO -    Extracting files...
2025-02-03 01:51:51,457 - tasks.build_database - INFO -    Creating or updating tables in the database...
2025-02-03 01:53:26,641 - tasks.build_database - INFO -    Cleaning up cache...
2025-02-03 01:53:27,838 - tasks.build_database - INFO - Processing SISE-Eaux dataset for 2024...
2025-02-03 01:54:20,804 - tasks.build_database - INFO -    Extracting files...
2025-02-03 01:55:20,821 - tasks.build_database - INFO -    Creating or updating tables in the database...
2025-02-03 01:56:46,998 - tasks.build_database - INFO -    Cleaning up cache...
2025-02-03 01:56:48,688 - tasks.build_database - INFO - Cleaning up cache...
2025-02-03 01:56:48,691 - root - INFO - Task build_database completed.


```

I have run some checks:

```shell
uv run pipelines/run.py run build_database

        SELECT COUNT(*)
        FROM sise_prelevements;
        
   count_star()
0       3684554

        SELECT annee_prelevement, COUNT(*)
        FROM sise_prelevements
        group by annee_prelevement;
        
   annee_prelevement  count_star()
0               2016        398366
1               2017        402015
2               2018        403663
3               2019        409081
4               2020        406865
5               2021        414561
6               2022        421756
7               2023        424035
8               2024        404212

```

## Ideas 
I have also some ideas but wants your opinion on them:
- Move `check_table_existence` to **_common.py**
- Split `download_extract_insert_yearly_SISE_data` into `download_extract_SISE_data` and `insert_SISE_data_to_duckdb` for a better readability
- I guess the `refresh_type = all  ` in `process_sise_eaux_dataset()` should drop the tables entirely instead of deleting every year data.