### PR TITLE
Feature/request by specific year

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,22 @@ Tout le code dans pipelines sera installé en tant que package python automatiqu
 ### Comment construire la database
 
 Une fois l'environnement python setup avec uv, vous pouvez lancer data_pipeline/run.py pour remplir la database
-Il suffit de lancer
+
+Le téléchargement des données peut se faire de plusieurs manières :
+* 1. Téléchargement des données de la dernière année (par défaut)
+```bash
+uv run pipelines/run.py run build_database --refresh-type last
+```
+
+* 2. Téléchargement de toutes les données
 
 ```bash
-uv run pipelines/run.py run build_database
+uv run pipelines/run.py run build_database --refresh-type all
+```
+
+* 3. Téléchargement de données d'années spécifiques
+```bash
+uv run pipelines/run.py run build_database --refresh-type custom --custom-years 2018,2024,...
 ```
 
 ### Comment télécharger la database depuis S3

--- a/pipelines/config/.env.example
+++ b/pipelines/config/.env.example
@@ -1,3 +1,2 @@
 SCW_ACCESS_KEY=MyKey
 SCW_SECRET_KEY=MySecret
-ENV=dev

--- a/pipelines/run.py
+++ b/pipelines/run.py
@@ -21,14 +21,22 @@ def cli():
 def list():
     """List all available tasks."""
     tasks_dir = os.path.join(os.path.dirname(__file__), "tasks")
-    click.echo("Available tasks:")
-    for filename in os.listdir(tasks_dir):
+
+    for filename in sorted(os.listdir(tasks_dir)):
         if filename.endswith(".py") and not filename.startswith("_"):
             module_name = filename[:-3]
             module = importlib.import_module(f"tasks.{module_name}")
-            description = module.__doc__ or "No description"
-            description = description.strip().split("\n")[0]
-            click.echo(f"- {module_name}: {description}")
+
+            doc = module.__doc__ or "No description"
+            doc_lines = doc.strip().split("\n")
+            while doc_lines and not doc_lines[0].strip():
+                doc_lines.pop(0)
+            while doc_lines and not doc_lines[-1].strip():
+                doc_lines.pop()
+
+            click.echo(f"\n{module_name}:")
+            for line in doc_lines:
+                click.echo(f"    {line}")
 
 
 @cli.command()
@@ -38,11 +46,13 @@ def list():
     type=click.Choice(["all", "last", "custom"]),
     default="all",
     help="Type of refresh to perform",
+    hidden=True,
 )
 @click.option(
     "--custom-years",
     type=str,
     help="Comma-separated list of years to process (for custom refresh type)",
+    hidden=True,
 )
 def run(task_name, refresh_type, custom_years):
     """Run a specified task."""
@@ -50,15 +60,15 @@ def run(task_name, refresh_type, custom_years):
         module = importlib.import_module(f"tasks.{task_name}")
         task_func = getattr(module, "execute")
         logging.info(f"Starting task {task_name}...")
-        
+
         # Parse custom years if provided
         custom_years_list = None
         if custom_years:
             custom_years_list = [year.strip() for year in custom_years.split(",")]
-        
+
         # Call the task function with parameters
         task_func(refresh_type=refresh_type, custom_years=custom_years_list)
-        
+
         logging.info(f"Task {task_name} completed.")
     except (ModuleNotFoundError, AttributeError):
         logging.error(f"Task {task_name} not found.")

--- a/pipelines/run.py
+++ b/pipelines/run.py
@@ -33,13 +33,32 @@ def list():
 
 @cli.command()
 @click.argument("task_name")
-def run(task_name):
+@click.option(
+    "--refresh-type",
+    type=click.Choice(["all", "last", "custom"]),
+    default="all",
+    help="Type of refresh to perform",
+)
+@click.option(
+    "--custom-years",
+    type=str,
+    help="Comma-separated list of years to process (for custom refresh type)",
+)
+def run(task_name, refresh_type, custom_years):
     """Run a specified task."""
     try:
         module = importlib.import_module(f"tasks.{task_name}")
         task_func = getattr(module, "execute")
         logging.info(f"Starting task {task_name}...")
-        task_func()
+        
+        # Parse custom years if provided
+        custom_years_list = None
+        if custom_years:
+            custom_years_list = [year.strip() for year in custom_years.split(",")]
+        
+        # Call the task function with parameters
+        task_func(refresh_type=refresh_type, custom_years=custom_years_list)
+        
         logging.info(f"Task {task_name} completed.")
     except (ModuleNotFoundError, AttributeError):
         logging.error(f"Task {task_name} not found.")

--- a/pipelines/tasks/_common.py
+++ b/pipelines/tasks/_common.py
@@ -11,7 +11,7 @@ os.makedirs(CACHE_FOLDER, exist_ok=True)
 os.makedirs(DATABASE_FOLDER, exist_ok=True)
 
 
-def clear_cache(recreate_folder:bool=True):
+def clear_cache(recreate_folder: bool = True):
     """Clear the cache folder."""
     shutil.rmtree(CACHE_FOLDER)
     if recreate_folder:

--- a/pipelines/tasks/_common.py
+++ b/pipelines/tasks/_common.py
@@ -11,6 +11,8 @@ os.makedirs(CACHE_FOLDER, exist_ok=True)
 os.makedirs(DATABASE_FOLDER, exist_ok=True)
 
 
-def clear_cache():
+def clear_cache(recreate_folder:bool=True):
     """Clear the cache folder."""
     shutil.rmtree(CACHE_FOLDER)
+    if recreate_folder:
+        os.makedirs(CACHE_FOLDER, exist_ok=True)

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -169,11 +169,19 @@ def process_edc_datasets(
         years_to_update = available_years[-1:]
     elif refresh_type == "custom":
         if custom_years:
-            years_to_update = list(set(custom_years).intersection(available_years))
+            # Check if every year provided are available
+            invalid_years = set(custom_years) - set(available_years)
+            if invalid_years:
+                raise ValueError(
+                    f"Invalid years provided: {sorted(invalid_years)}. Years must be among: {available_years}"
+                )
+            # Filtering and sorting of valid years
+            years_to_update = sorted(list(set(custom_years).intersection(available_years)))
         else:
             raise ValueError(
                 """ custom_years parameter needs to be specified if refresh_type="custom" """
             )
+
     else:
         raise ValueError(
             f""" refresh_type needs to be one of ["all", "last", "custom"], it can't be: {refresh_type}"""
@@ -189,5 +197,11 @@ def process_edc_datasets(
     return True
 
 
-def execute():
-    process_edc_datasets()
+def execute(refresh_type: str = "all", custom_years: List[str] = None):
+    """
+    Execute the EDC dataset processing with specified parameters.
+    
+    :param refresh_type: Type of refresh to perform ("all", "last", or "custom")
+    :param custom_years: List of years to process when refresh_type is "custom"
+    """
+    process_edc_datasets(refresh_type=refresh_type, custom_years=custom_years)

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -1,10 +1,13 @@
 """
-Consolidate data into the database.
+Consolidate data into the database.\n
+Args:
+    - refresh-type (str): Type of refresh to perform ("all", "last", or "custom")
+    - custom-years (list[str]): List of years to process when refresh_type is "custom"
 """
 
 import logging
 import os
-from typing import Dict, List, Literal
+from typing import List, Literal
 from zipfile import ZipFile
 
 import duckdb
@@ -31,7 +34,6 @@ def check_table_existence(conn: duckdb.DuckDBPyConnection, table_name: str) -> b
         """
     conn.execute(query)
     return list(conn.fetchone())[0] == 1
-
 
 
 def download_extract_insert_yearly_edc_data(year: str):
@@ -134,7 +136,9 @@ def process_edc_datasets(
                     f"Invalid years provided: {sorted(invalid_years)}. Years must be among: {available_years}"
                 )
             # Filtering and sorting of valid years
-            years_to_update = sorted(list(set(custom_years).intersection(available_years)))
+            years_to_update = sorted(
+                list(set(custom_years).intersection(available_years))
+            )
         else:
             raise ValueError(
                 """ custom_years parameter needs to be specified if refresh_type="custom" """
@@ -153,10 +157,11 @@ def process_edc_datasets(
     clear_cache(recreate_folder=False)
     return True
 
+
 def execute(refresh_type: str = "all", custom_years: List[str] = None):
     """
     Execute the EDC dataset processing with specified parameters.
-    
+
     :param refresh_type: Type of refresh to perform ("all", "last", or "custom")
     :param custom_years: List of years to process when refresh_type is "custom"
     """

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -1,8 +1,14 @@
 """
-Consolidate data into the database.\n
+Consolidate data into the database.
+
 Args:
     - refresh-type (str): Type of refresh to perform ("all", "last", or "custom")
-    - custom-years (list[str]): List of years to process when refresh_type is "custom"
+    - custom-years (str): List of years to process when refresh_type is "custom"
+
+Examples:
+    - build_database --refresh-type all : Process all years
+    - build_database --refresh-type last : Process last year only
+    - build_database --refresh-type custom --custom-years 2018,2024 : Process only the years 2018 and 2024
 """
 
 import logging

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -62,7 +62,7 @@ def download_extract_insert_yearly_edc_data(year: str):
     extracts the files and insert the data into duckdb
     :param year: The year from which we want to download the dataset
     :return: Create or replace the associated tables in the duckcb database.
-        It adds the column "annee_prelevement" based on year as an integer.
+        It adds the column "de_partition" based on year as an integer.
     """
 
     yearly_dataset_info = get_yearly_edc_infos(year=year)
@@ -112,7 +112,7 @@ def download_extract_insert_yearly_edc_data(year: str):
         if check_table_existence(conn=conn, table_name=f"{file_info['table_name']}"):
             query = f"""
                 DELETE FROM {f"{file_info['table_name']}"}
-                WHERE annee_prelevement = CAST({year} as INTEGER)
+                WHERE de_partition = CAST({year} as INTEGER)
                 ;
             """
             conn.execute(query)
@@ -124,7 +124,7 @@ def download_extract_insert_yearly_edc_data(year: str):
         query_select = f"""
             SELECT 
                 *,
-                CAST({year} as INTEGER) AS annee_prelevement
+                CAST({year} as INTEGER) AS de_partition
             FROM read_csv('{filepath}', header=true, delim=',');
         """
 

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -165,7 +165,7 @@ def process_sise_eaux_dataset(
     if refresh_type == "all":
         years_to_update = available_years
     elif refresh_type == "last":
-        years_to_update = available_years[-1]
+        years_to_update = available_years[-1:]
     elif refresh_type == "custom":
         if custom_years:
             years_to_update = list(set(custom_years).intersection(available_years))

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -174,6 +174,10 @@ def process_edc_datasets(
             raise ValueError(
                 """ custom_years parameter needs to be specified if refresh_type="custom" """
             )
+    else:
+        raise ValueError(
+            f""" refresh_type needs to be one of ["all", "last", "custom"], it can't be: {refresh_type}"""
+        )
 
     logger.info(
         f"Launching processing of EDC datasets for years: {years_to_update}"

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -73,17 +73,17 @@ def download_extract_insert_yearly_SISE_data(year: str):
         },
     }
 
-    logger.info(f"Downloading and extracting SISE-Eaux dataset for {year}...")
+    logger.info(f"Processing SISE-Eaux dataset for {year}...")
     response = requests.get(DATA_URL, stream=True)
     with open(ZIP_FILE, "wb") as f:
         for chunk in response.iter_content(chunk_size=8192):
             f.write(chunk)
 
-    logger.info("Extracting files...")
+    logger.info("   Extracting files...")
     with ZipFile(ZIP_FILE, "r") as zip_ref:
         zip_ref.extractall(EXTRACT_FOLDER)
 
-    logger.info("Creating tables in the database...")
+    logger.info("   Creating or updating tables in the database...")
     conn = duckdb.connect(DUCKDB_FILE)
 
     for file_info in FILES.values():
@@ -115,7 +115,7 @@ def download_extract_insert_yearly_SISE_data(year: str):
 
     conn.close()
 
-    logger.info("Cleaning up...")
+    logger.info("   Cleaning up cache...")
     clear_cache()
 
     return True
@@ -174,9 +174,15 @@ def process_sise_eaux_dataset(
                 """ custom_years parameter needs to be specified if refresh_type="custom" """
             )
 
+    logger.info(
+        f"Launching processing of SISE-Eaux dataset for years: {years_to_update}"
+    )
+
     for year in years_to_update:
         download_extract_insert_yearly_SISE_data(year=year)
 
+    logger.info("Cleaning up cache...")
+    clear_cache(recreate_folder=False)
     return True
 
 

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -83,5 +83,15 @@ def process_sise_eaux_dataset_2024(year:str):
     return True
 
 
+def check_table_existence(conn, table_name):
+    query = f"""
+        SELECT COUNT(*)
+        FROM information_schema.tables
+        WHERE table_name = '{table_name}'
+        """
+    conn.execute(query)
+    return list(conn.fetchone())[0] == 1
+
+
 def execute():
     process_sise_eaux_dataset_2024(year="2024")

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -39,23 +39,24 @@ def get_yearly_dataset_infos(year:str) -> Dict[str,str]:
     return dis_files_info_by_year[year]
 
 
-def process_sise_eaux_dataset_2024():
+def process_sise_eaux_dataset_2024(year:str):
     """Process SISE-Eaux dataset for 2024."""
 
+    yearly_dataset_info = get_yearly_dataset_infos(year = year)
     # Dataset specific constants
     DATA_URL = (
-        "https://www.data.gouv.fr/fr/datasets/r/84a67a3b-08a7-4001-98e6-231c74a98139"
+        f"https://www.data.gouv.fr/fr/datasets/r/{yearly_dataset_info["id"]}"
     )
-    ZIP_FILE = os.path.join(CACHE_FOLDER, "dis-2024.zip")
-    EXTRACT_FOLDER = os.path.join(CACHE_FOLDER, "raw_data_2024")
+    ZIP_FILE = os.path.join(CACHE_FOLDER, yearly_dataset_info["name"])
+    EXTRACT_FOLDER = os.path.join(CACHE_FOLDER, f"raw_data_{year}")
 
     FILES = {
-        "communes": {"filename": "DIS_COM_UDI_2024.txt", "table": "sise_communes"},
-        "prelevements": {"filename": "DIS_PLV_2024.txt", "table": "sise_prelevements"},
-        "resultats": {"filename": "DIS_RESULT_2024.txt", "table": "sise_resultats"},
+        "communes": {"filename": f"DIS_COM_UDI_{year}.txt", "table": f"sise_communes_{year}"},
+        "prelevements": {"filename": f"DIS_PLV_{year}.txt", "table": f"sise_prelevements_{year}"},
+        "resultats": {"filename": f"DIS_RESULT_{year}.txt", "table": f"sise_resultats_{year}"},
     }
 
-    logger.info("Downloading and extracting SISE-Eaux dataset for 2024...")
+    logger.info(f"Downloading and extracting SISE-Eaux dataset for {year}...")
     response = requests.get(DATA_URL, stream=True)
     with open(ZIP_FILE, "wb") as f:
         for chunk in response.iter_content(chunk_size=8192):
@@ -83,4 +84,4 @@ def process_sise_eaux_dataset_2024():
 
 
 def execute():
-    process_sise_eaux_dataset_2024()
+    process_sise_eaux_dataset_2024(year="2024")

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -191,5 +191,3 @@ def process_edc_datasets(
 
 def execute():
     process_edc_datasets()
-
-    conn = duckdb.connect(DUCKDB_FILE)

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -15,6 +15,22 @@ from ._common import CACHE_FOLDER, DUCKDB_FILE, clear_cache
 logger = logging.getLogger(__name__)
 
 
+def check_table_existence(conn: duckdb.DuckDBPyConnection, table_name: str) -> bool:
+    """
+    Check if a table exists in the duckdb database
+    :param conn: The duckdb connection to use
+    :param table_name: The table name to check existence
+    :return: True if the table exists, False if not
+    """
+    query = f"""
+        SELECT COUNT(*)
+        FROM information_schema.tables
+        WHERE table_name = '{table_name}'
+        """
+    conn.execute(query)
+    return list(conn.fetchone())[0] == 1
+
+
 def get_yearly_dataset_infos(year: str) -> Dict[str, str]:
     """
     Returns information for yearly dataset extract of the SISE Eaux datasets.
@@ -119,22 +135,6 @@ def download_extract_insert_yearly_SISE_data(year: str):
     clear_cache()
 
     return True
-
-
-def check_table_existence(conn: duckdb.DuckDBPyConnection, table_name: str) -> bool:
-    """
-    Check if a table exists in the duckdb database
-    :param conn: The duckdb connection to use
-    :param table_name: The table name to check existence
-    :return: True if the table exists, False if not
-    """
-    query = f"""
-        SELECT COUNT(*)
-        FROM information_schema.tables
-        WHERE table_name = '{table_name}'
-        """
-    conn.execute(query)
-    return list(conn.fetchone())[0] == 1
 
 
 def process_sise_eaux_dataset(

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -179,9 +179,7 @@ def process_edc_datasets(
             f""" refresh_type needs to be one of ["all", "last", "custom"], it can't be: {refresh_type}"""
         )
 
-    logger.info(
-        f"Launching processing of EDC datasets for years: {years_to_update}"
-    )
+    logger.info(f"Launching processing of EDC datasets for years: {years_to_update}")
 
     for year in years_to_update:
         download_extract_insert_yearly_edc_data(year=year)

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -4,6 +4,7 @@ Consolidate data into the database.
 
 import logging
 import os
+from typing import Dict
 from zipfile import ZipFile
 
 import duckdb
@@ -12,6 +13,30 @@ import requests
 from ._common import CACHE_FOLDER, DUCKDB_FILE, clear_cache
 
 logger = logging.getLogger(__name__)
+
+def get_yearly_dataset_infos(year:str) -> Dict[str,str]:
+    """
+    Returns information for yearly dataset extract of the SISE Eaux datasets.
+    The data comes from https://www.data.gouv.fr/fr/datasets/resultats-du-controle-sanitaire-de-leau-distribuee-commune-par-commune/
+    For each year a dataset is downloadable on a URL like this (ex. 2024):
+        https://www.data.gouv.fr/fr/datasets/r/84a67a3b-08a7-4001-98e6-231c74a98139
+    The id of the dataset is the last part of this URL
+    The name of the dataset is dis-YEAR.zip (but the format could potentially change).
+    :param year: The year from which we want to get the dataset information.
+    :return: A dict with the id and name of the dataset.
+    """
+    dis_files_info_by_year = {
+        "2024": {"id": "84a67a3b-08a7-4001-98e6-231c74a98139", "name" : "dis-2024.zip"},
+        "2023": {"id":"c89dec4a-d985-447c-a102-75ba814c398e", "name" : "dis-2023.zip"},
+        "2022": {"id":"a97b6074-c4dd-4ef2-8922-b0cf04dbff9a", "name" : "dis-2022.zip"},
+        "2021": {"id":"d2b432cc-3761-44d3-8e66-48bc15300bb5", "name" : "dis-2021.zip"},
+        "2020": {"id":"a6cb4fea-ef8c-47a5-acb3-14e49ccad801", "name" : "dis-2020.zip"},
+        "2019": {"id":"861f2a7d-024c-4bf0-968b-9e3069d9de07", "name" : "dis-2019.zip"},
+        "2018": {"id":"0513b3c0-dc18-468d-a969-b3508f079792", "name" : "dis-2018.zip"},
+        "2017": {"id":"5785427b-3167-49fa-a581-aef835f0fb04", "name" : "dis-2017.zip"},
+        "2016": {"id":"483c84dd-7912-483b-b96f-4fa5e1d8651f", "name" : "dis-2016.zip"}
+    }
+    return dis_files_info_by_year[year]
 
 
 def process_sise_eaux_dataset_2024():

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -4,7 +4,7 @@ Consolidate data into the database.
 
 import logging
 import os
-from typing import Dict
+from typing import Dict, List, Literal
 from zipfile import ZipFile
 
 import duckdb
@@ -14,7 +14,8 @@ from ._common import CACHE_FOLDER, DUCKDB_FILE, clear_cache
 
 logger = logging.getLogger(__name__)
 
-def get_yearly_dataset_infos(year:str) -> Dict[str,str]:
+
+def get_yearly_dataset_infos(year: str) -> Dict[str, str]:
     """
     Returns information for yearly dataset extract of the SISE Eaux datasets.
     The data comes from https://www.data.gouv.fr/fr/datasets/resultats-du-controle-sanitaire-de-leau-distribuee-commune-par-commune/
@@ -26,15 +27,15 @@ def get_yearly_dataset_infos(year:str) -> Dict[str,str]:
     :return: A dict with the id and name of the dataset.
     """
     dis_files_info_by_year = {
-        "2024": {"id": "84a67a3b-08a7-4001-98e6-231c74a98139", "name" : "dis-2024.zip"},
-        "2023": {"id":"c89dec4a-d985-447c-a102-75ba814c398e", "name" : "dis-2023.zip"},
-        "2022": {"id":"a97b6074-c4dd-4ef2-8922-b0cf04dbff9a", "name" : "dis-2022.zip"},
-        "2021": {"id":"d2b432cc-3761-44d3-8e66-48bc15300bb5", "name" : "dis-2021.zip"},
-        "2020": {"id":"a6cb4fea-ef8c-47a5-acb3-14e49ccad801", "name" : "dis-2020.zip"},
-        "2019": {"id":"861f2a7d-024c-4bf0-968b-9e3069d9de07", "name" : "dis-2019.zip"},
-        "2018": {"id":"0513b3c0-dc18-468d-a969-b3508f079792", "name" : "dis-2018.zip"},
-        "2017": {"id":"5785427b-3167-49fa-a581-aef835f0fb04", "name" : "dis-2017.zip"},
-        "2016": {"id":"483c84dd-7912-483b-b96f-4fa5e1d8651f", "name" : "dis-2016.zip"}
+        "2024": {"id": "84a67a3b-08a7-4001-98e6-231c74a98139", "name": "dis-2024.zip"},
+        "2023": {"id": "c89dec4a-d985-447c-a102-75ba814c398e", "name": "dis-2023.zip"},
+        "2022": {"id": "a97b6074-c4dd-4ef2-8922-b0cf04dbff9a", "name": "dis-2022.zip"},
+        "2021": {"id": "d2b432cc-3761-44d3-8e66-48bc15300bb5", "name": "dis-2021.zip"},
+        "2020": {"id": "a6cb4fea-ef8c-47a5-acb3-14e49ccad801", "name": "dis-2020.zip"},
+        "2019": {"id": "861f2a7d-024c-4bf0-968b-9e3069d9de07", "name": "dis-2019.zip"},
+        "2018": {"id": "0513b3c0-dc18-468d-a969-b3508f079792", "name": "dis-2018.zip"},
+        "2017": {"id": "5785427b-3167-49fa-a581-aef835f0fb04", "name": "dis-2017.zip"},
+        "2016": {"id": "483c84dd-7912-483b-b96f-4fa5e1d8651f", "name": "dis-2016.zip"},
     }
     return dis_files_info_by_year[year]
 
@@ -120,7 +121,13 @@ def download_extract_insert_yearly_SISE_data(year: str):
     return True
 
 
-def check_table_existence(conn, table_name):
+def check_table_existence(conn: duckdb.DuckDBPyConnection, table_name: str) -> bool:
+    """
+    Check if a table exists in the duckdb database
+    :param conn: The duckdb connection to use
+    :param table_name: The table name to check existence
+    :return: True if the table exists, False if not
+    """
     query = f"""
         SELECT COUNT(*)
         FROM information_schema.tables
@@ -174,4 +181,4 @@ def process_sise_eaux_dataset(
 
 
 def execute():
-    process_sise_eaux_dataset_2024(year="2024")
+    process_sise_eaux_dataset()

--- a/pipelines/tasks/download_database.py
+++ b/pipelines/tasks/download_database.py
@@ -1,3 +1,14 @@
+"""
+Download database from S3 storage.
+
+Args:
+    - env (str): Environment to download from ("dev" or "prod")
+
+Examples:
+    - download_database --env prod : Download database from production environment
+    - download_database --env dev  : Download database from development environment
+"""
+
 import logging
 
 from pipelines.config.config import get_environment, get_s3_path

--- a/pipelines/tasks/upload_database.py
+++ b/pipelines/tasks/upload_database.py
@@ -1,3 +1,14 @@
+"""
+Upload database to S3 storage.
+
+Args:
+    - env (str): Environment to upload to ("dev" or "prod")
+
+Examples:
+    - upload_database --env dev  : Upload database to development environment
+    - upload_database --env prod : Upload database to production environment
+"""
+
 import logging
 
 from pipelines.config.config import get_environment, get_s3_path


### PR DESCRIPTION
CLI arguments have been added to request data by specific years : 
* --refresh-type : type of refresh to perform. This could be a full refresh ("all"), a collection of last year data ("last") or a collection of specific years ("custom").
* --custom-years : in case where --refresh-type custom have been specified, the user can indicate the years of data he wanted to collect. Years have to be comma separated. Example of a CLI command : `uv run pipelines/run.py run build_database --refresh-type custom --custom-years 2018,2024`