### PR TITLE
build_database.py / Add option to drop EDC tables

### DIFF
--- a/pipelines/run.py
+++ b/pipelines/run.py
@@ -61,7 +61,14 @@ def run():
     type=str,
     help="Comma-separated list of years to process (for custom refresh type)",
 )
-def run_build_database(refresh_type, custom_years):
+@click.option(
+    "--reset-tables",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Drop and re-create edc tables in the database before data insertion.",
+)
+def run_build_database(refresh_type, custom_years, reset_tables):
     """Run build_database task."""
     module = importlib.import_module("tasks.build_database")
     task_func = getattr(module, "execute")
@@ -70,7 +77,11 @@ def run_build_database(refresh_type, custom_years):
     if custom_years:
         custom_years_list = [year.strip() for year in custom_years.split(",")]
 
-    task_func(refresh_type=refresh_type, custom_years=custom_years_list)
+    task_func(
+        refresh_type=refresh_type,
+        custom_years=custom_years_list,
+        reset_tables=reset_tables,
+    )
 
 
 @run.command("download_database")

--- a/pipelines/run.py
+++ b/pipelines/run.py
@@ -62,13 +62,13 @@ def run():
     help="Comma-separated list of years to process (for custom refresh type)",
 )
 @click.option(
-    "--reset-tables",
+    "--drop-tables",
     is_flag=True,
     show_default=True,
     default=False,
     help="Drop and re-create edc tables in the database before data insertion.",
 )
-def run_build_database(refresh_type, custom_years, reset_tables):
+def run_build_database(refresh_type, custom_years, drop_tables):
     """Run build_database task."""
     module = importlib.import_module("tasks.build_database")
     task_func = getattr(module, "execute")
@@ -80,7 +80,7 @@ def run_build_database(refresh_type, custom_years, reset_tables):
     task_func(
         refresh_type=refresh_type,
         custom_years=custom_years_list,
-        reset_tables=reset_tables,
+        drop_tables=drop_tables,
     )
 
 

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -114,17 +114,32 @@ def download_extract_insert_yearly_edc_data(year: str):
     return True
 
 
+def drop_edc_tables():
+    """Drop tables using tables names defined in _config_edc.py"""
+    conn = duckdb.connect(DUCKDB_FILE)
+    tables_names = [
+        file_info["table_name"] for file_info in edc_config["files"].values()
+    ]
+    for table_name in tables_names:
+        query = f"DROP TABLE IF EXISTS {table_name};"
+        logger.info(f"Drop table {table_name} (query: {query})")
+        conn.execute(query)
+    return True
+
+
 def process_edc_datasets(
     refresh_type: Literal["all", "last", "custom"] = "last",
     custom_years: List[str] = None,
+    reset_tables: bool = False,
 ):
     """
     Process the EDC datasets.
     :param refresh_type: Refresh type to run
-        - "all": Refresh the data for every possible year
+        - "all": Drop edc tables and import the data for every possible year.
         - "last": Refresh the data only for the last available year
         - "custom": Refresh the data for the years specified in the list custom_years
     :param custom_years: years to update
+    :param reset_tables: Whether to drop edc tables in the database before data insertion.
     :return:
     """
     available_years = edc_config["source"]["available_years"]
@@ -156,6 +171,9 @@ def process_edc_datasets(
 
     logger.info(f"Launching processing of EDC datasets for years: {years_to_update}")
 
+    if reset_tables or (refresh_type == "all"):
+        drop_edc_tables()
+
     for year in years_to_update:
         download_extract_insert_yearly_edc_data(year=year)
 
@@ -164,11 +182,18 @@ def process_edc_datasets(
     return True
 
 
-def execute(refresh_type: str = "all", custom_years: List[str] = None):
+def execute(
+    refresh_type: str = "all",
+    custom_years: List[str] = None,
+    reset_tables: bool = False,
+):
     """
     Execute the EDC dataset processing with specified parameters.
 
     :param refresh_type: Type of refresh to perform ("all", "last", or "custom")
     :param custom_years: List of years to process when refresh_type is "custom"
+    :param reset_tables: Whether to drop edc tables in the database before data insertion.
     """
-    process_edc_datasets(refresh_type=refresh_type, custom_years=custom_years)
+    process_edc_datasets(
+        refresh_type=refresh_type, custom_years=custom_years, reset_tables=reset_tables
+    )

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -130,7 +130,7 @@ def drop_edc_tables():
 def process_edc_datasets(
     refresh_type: Literal["all", "last", "custom"] = "last",
     custom_years: List[str] = None,
-    reset_tables: bool = False,
+    drop_tables: bool = False,
 ):
     """
     Process the EDC datasets.
@@ -139,7 +139,7 @@ def process_edc_datasets(
         - "last": Refresh the data only for the last available year
         - "custom": Refresh the data for the years specified in the list custom_years
     :param custom_years: years to update
-    :param reset_tables: Whether to drop edc tables in the database before data insertion.
+    :param drop_tables: Whether to drop edc tables in the database before data insertion.
     :return:
     """
     available_years = edc_config["source"]["available_years"]
@@ -171,7 +171,7 @@ def process_edc_datasets(
 
     logger.info(f"Launching processing of EDC datasets for years: {years_to_update}")
 
-    if reset_tables or (refresh_type == "all"):
+    if drop_tables or (refresh_type == "all"):
         drop_edc_tables()
 
     for year in years_to_update:
@@ -185,15 +185,15 @@ def process_edc_datasets(
 def execute(
     refresh_type: str = "all",
     custom_years: List[str] = None,
-    reset_tables: bool = False,
+    drop_tables: bool = False,
 ):
     """
     Execute the EDC dataset processing with specified parameters.
 
     :param refresh_type: Type of refresh to perform ("all", "last", or "custom")
     :param custom_years: List of years to process when refresh_type is "custom"
-    :param reset_tables: Whether to drop edc tables in the database before data insertion.
+    :param drop_tables: Whether to drop edc tables in the database before data insertion.
     """
     process_edc_datasets(
-        refresh_type=refresh_type, custom_years=custom_years, reset_tables=reset_tables
+        refresh_type=refresh_type, custom_years=custom_years, drop_tables=drop_tables
     )


### PR DESCRIPTION
This is a proposal for adding `--drop-tables` parameter to the `pipelines/run.py run build_database` command.

**New behavior** : 
- `refresh_type='all'` will run the `DROP TABLE IF EXISTS {table_name}` for all tables names in the `edc_config`. 
- a new parameter is added : `drop_tables (--drop-tables)` to drop edc tables even if `refresh_type != 'all'`.


This is the NOCODB issue : https://noco.services.dataforgood.fr/dashboard/#/nc/pk1vq1pm8frc5lm/ms9uz8er4jpow7j/Kanban%20data%20eng?rowId=82

> **Contexte**:
> Aujourd'hui les données sont insérées dans les tables en supprimant les données (DELETE FROM ..) ayant la valeur de l'année paramétrée dans la colonne de_partition, puis en les insérant (INSERT INTO).
> Le problème est qu'en cas de changement de schéma de données il faut manuellement supprimer les tables en:
> supprimant le fichier database/data.duckdb
> En lançant les commandes SQL drop tables edc_resultats, edc_communes, edc_prelevements;
> **Livrable**:
> Ajouter un paramètre permettant de supprimer les tables avant de les recréer afin de faciliter les éventuels changement de schema et les runs pour les dev ayant déjà une db en local.
> L'ajout peut être dans la fonction process_edc_datasets ou autre part si proposition plus approprié.
> Dans l'idée un refresh_type = "all" devrait drop puis replace les tables.


