### PR TITLE
Feat: Upload database.duckdb with public visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,19 @@ uv run pipelines/run.py run build_database --refresh-type last --drop-tables
 
 ### Comment télécharger la database depuis S3
 
+
 Des versions de dev et de production de la db sont à disposition sur le storage object.
-Il faut bien configurer ses credentials et son env via le fichier .env.
-Ensuite il suffit de lancer
+Les deux façons de télécharger les databases suivantes existent.
+
+#### via HTTPS
+Le plus simple est de la télécharger via https (pas besoin de credentials):
+```bash
+uv run pipelines/run.py run download_database_https --env prod
+```
+
+#### via S3 (Scaleway)
+Il faut bien configurer ses credentials Scaleway et son env [via le fichier .env.](#connection-a-scaleway-via-boto3-pour-stockage-cloud)
+
 
 ```bash
 uv run pipelines/run.py run download_database

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ uv run pipelines/run.py run download_database_https --env prod
 ```
 
 #### via S3 (Scaleway)
-Il faut bien configurer ses credentials Scaleway et son env [via le fichier .env.](#connection-a-scaleway-via-boto3-pour-stockage-cloud)
+Il faut bien configurer ses credentials Scaleway et son env via le fichier .env.
 
 
 ```bash

--- a/pipelines/run.py
+++ b/pipelines/run.py
@@ -104,6 +104,24 @@ def run_download_database(env):
     task_func(env)
 
 
+@run.command("download_database_https")
+@click.option(
+    "--env",
+    type=click.Choice(["dev", "prod"]),
+    default=None,
+    help="Environment to download from. It will override environment defined in .env",
+)
+def run_download_database_https(env):
+    """Download database from S3 via HTTPS."""
+    if env is not None:
+        os.environ["ENV"] = env
+    env = get_environment(default="prod")
+    logger.info(f"Running on env {env}")
+    module = importlib.import_module("tasks.download_database_https")
+    task_func = getattr(module, "execute")
+    task_func(env)
+
+
 @run.command("upload_database")
 @click.option(
     "--env",

--- a/pipelines/tasks/_common.py
+++ b/pipelines/tasks/_common.py
@@ -1,6 +1,9 @@
 import os
 import shutil
-
+from pathlib import Path
+import requests
+from typing import Union
+from tqdm import tqdm
 
 ROOT_FOLDER = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 DATABASE_FOLDER = os.path.join(ROOT_FOLDER, "database")
@@ -10,9 +13,41 @@ CACHE_FOLDER = os.path.join(ROOT_FOLDER, "database", "cache")
 os.makedirs(CACHE_FOLDER, exist_ok=True)
 os.makedirs(DATABASE_FOLDER, exist_ok=True)
 
+# common style for the progressbar dans cli
+tqdm_common = {
+    "ncols": 100,
+    "bar_format": "{l_bar}{bar}| {n_fmt}/{total_fmt}",
+}
+
 
 def clear_cache(recreate_folder: bool = True):
     """Clear the cache folder."""
     shutil.rmtree(CACHE_FOLDER)
     if recreate_folder:
         os.makedirs(CACHE_FOLDER, exist_ok=True)
+
+
+def download_file_from_https(url: str, filepath: Union[str, Path]):
+    """
+    Downloads a file from a https link to a local file.
+    :param url: The url where to download the file.
+    :param filepath: The path to the local file.
+    :return: Downloaded file filename.
+    """
+    response = requests.get(url, stream=True)
+    response.raise_for_status()
+    response_size = int(response.headers.get("content-length", 0))
+    filepath = Path(filepath)
+    with open(filepath, "wb") as f:
+        with tqdm(
+            total=response_size,
+            unit="B",
+            unit_scale=True,
+            desc=f"Processing file {filepath.name}",
+            **tqdm_common,
+        ) as pbar:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+                pbar.update(len(chunk))
+
+    return filepath.name

--- a/pipelines/tasks/build_database.py
+++ b/pipelines/tasks/build_database.py
@@ -18,9 +18,14 @@ from typing import List, Literal
 from zipfile import ZipFile
 
 import duckdb
-import requests
 
-from ._common import CACHE_FOLDER, DUCKDB_FILE, clear_cache
+from ._common import (
+    CACHE_FOLDER,
+    DUCKDB_FILE,
+    tqdm_common,
+    clear_cache,
+    download_file_from_https,
+)
 from ._config_edc import create_edc_yearly_filename, get_edc_config
 from tqdm import tqdm
 
@@ -66,26 +71,7 @@ def download_extract_insert_yearly_edc_data(year: str):
 
     logger.info(f"Processing EDC dataset for {year}...")
 
-    response = requests.get(DATA_URL, stream=True)
-    response_size = int(response.headers.get("content-length", 0))
-    # common style for the progressbar dans cli
-    tqdm_common = {
-        "ncols": 100,
-        "bar_format": "{l_bar}{bar}| {n_fmt}/{total_fmt}",
-    }
-
-    # Open the ZIP file for writing
-    with open(ZIP_FILE, "wb") as f:
-        with tqdm(
-            total=response_size,
-            unit="B",
-            unit_scale=True,
-            desc="Processing",
-            **tqdm_common,
-        ) as pbar:
-            for chunk in response.iter_content(chunk_size=8192):
-                f.write(chunk)
-                pbar.update(len(chunk))
+    download_file_from_https(url=DATA_URL, filepath=ZIP_FILE)
 
     logger.info("   Extracting files...")
     with ZipFile(ZIP_FILE, "r") as zip_ref:

--- a/pipelines/tasks/download_database_https.py
+++ b/pipelines/tasks/download_database_https.py
@@ -1,0 +1,36 @@
+"""
+Download database from HTTP Scaleway object storage public link.
+
+Args:
+    - env (str): Environment to download from ("dev" or "prod")
+
+Examples:
+    - download_database_https --env prod : Download database from production environment
+    - download_database_https --env dev  : Download database from development environment
+"""
+
+import logging
+
+from pipelines.config.config import get_s3_path
+from pipelines.tasks._common import DUCKDB_FILE
+from pipelines.utils.storage_client import ObjectStorageClient
+from ._common import download_file_from_https
+
+logger = logging.getLogger(__name__)
+
+
+def download_database_from_https(env):
+    """
+    Download the database from Storage Object depending on the environment
+    This requires setting the correct environment variables for the Scaleway credentials
+    """
+    s3 = ObjectStorageClient()
+    url = f"https://{s3.bucket_name}.{s3.endpoint_url.split('https://')[1]}/{get_s3_path(env)}"
+    local_db_path = DUCKDB_FILE
+
+    download_file_from_https(url=url, filepath=local_db_path)
+    logger.info(f"✅ Base téléchargée depuis s3 via HTTPS: {url} -> {local_db_path}")
+
+
+def execute(env):
+    download_database_from_https(env)

--- a/pipelines/tasks/upload_database.py
+++ b/pipelines/tasks/upload_database.py
@@ -28,7 +28,7 @@ def upload_database_to_storage(env):
     db_path = DUCKDB_FILE  # Fichier local
     s3_path = get_s3_path(env)  # Destination sur S3
 
-    s3.upload_object(db_path, s3_path)
+    s3.upload_object(local_path=db_path, file_key=s3_path, public_read=True)
     logger.info(f"✅ Base uploadée sur s3://{s3.bucket_name}/{s3_path}")
 
 

--- a/pipelines/utils/storage_client.py
+++ b/pipelines/utils/storage_client.py
@@ -43,10 +43,15 @@ class ObjectStorageClient:
     def download_object(self, file_key, local_path):
         self.client_v4.download_file(self.bucket_name, file_key, local_path)
 
-    def upload_object(self, local_path, file_key=None):
+    def upload_object(self, local_path, file_key=None, public_read=False):
         if file_key is None:
             file_key = os.path.basename(local_path)
-        self.client_v2.upload_file(local_path, self.bucket_name, file_key)
+        self.client_v2.upload_file(
+            local_path,
+            self.bucket_name,
+            file_key,
+            ExtraArgs={"ACL": "public-read"} if public_read else None,
+        )
 
     def upload_dataframe(self, df, file_key):
         csv_buffer = io.StringIO()


### PR DESCRIPTION
## Contexte:

Nous voulons exposer la base de donnée duckdb via https pour pouvoir la télécharger sans avoir besoin de setup de credentials.

Pour cela il faut que l'objet ait une [visibilité "public" sur scaleway](https://www.scaleway.com/en/docs/object-storage/how-to/manage-object-visibility/). A chaque upload de la database sur S3 le fichier est uploadé avec la visibilité privée par défaut. 
Les deux options sont donc: 
- Créer une bucket policy pour la clé associée aux fichiers de DB 
- Uploadé le fichier avec la visibilité en publique: cf cette capture de la doc Scaleway:
![image](https://github.com/user-attachments/assets/88b894a3-ce6c-48af-9207-a290851dc252)
C'est possible avec les `ExtraArgs={"ACL": "public-read"}` pour la fonction `s3.upload_file()`.

Si l'objet est public il suffit du lien associé (qui ne change pas car le nom du fichier est toujours le même).

## Changements

- Ajout du paramètre `public_read`  dans `upload_object()` pipelines/utils/storage_client.py avec None en default
- Utilisation du paramètre dans `upload_database_to_storage()` pipelines/tasks/upload_database.py. 

## Tests

- [x] tests sur un scaleway perso
- [x] tests sur le dev

``` commandline
(.venv) pascal@pascal:~/path/13_pollution_eau$ uv run pipelines/run.py run upload_database
2025-02-11 11:53:29,090 - tasks.upload_database - INFO - ✅ Base uploadée sur s3://pollution-eau-s3/dev/database/data.duckdb

```

Le fichier étant uploadé en `visibilité = public` on peut le télécharger avec le lien:
[https://pollution-eau-s3.s3.fr-par.scw.cloud/dev/database/data.duckdb](https://pollution-eau-s3.s3.fr-par.scw.cloud/dev/database/data.duckdb)
