### PR TITLE
Add cron to synchronize db workflow

### DIFF
--- a/.github/workflows/synchronize_db.yaml
+++ b/.github/workflows/synchronize_db.yaml
@@ -1,14 +1,17 @@
 name: 🔄 Synchronize Production DB to storage
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'pipelines/**'
-      - 'database/**'
-  # Allows you to run this workflow manually from the Actions tab
+  schedule:
+    # Execute pipeline every 1st and 15th of the month at 10:00 AM
+    - cron: '0 10 1,15 * *'
+
   workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Raison de la synchronisation'
+        required: true
+        type: string
+        default: 'Mise à jour manuelle de la base de données'
 
 env:
   ENV: prod
@@ -42,3 +45,16 @@ jobs:
     - name: Upload production database to Storage
       run: |
         uv run pipelines/run.py run upload_database
+
+    - name: Create Issue if Failed
+      if: failure()
+      uses: actions/github-script@v6
+      with:
+        script: |
+          github.rest.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.name,
+            title: '❌ Échec de la synchronisation de la base de données',
+            body: `La synchronisation de la base de données a échoué.\n\nVoir les détails : ${context.serverUrl}/${context.repo.owner}/${context.repo.name}/actions/runs/${context.runId}`,
+            labels: ['bug', 'database']
+          })


### PR DESCRIPTION
Replace push event trigger in  `.github/workflows/synchronize_db.yaml` by a scheduler that run each 1st and 15th of each month.