### PR TITLE
Feature : ajout d'une tâche VS Code pour télécharger la base de données

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,7 +21,7 @@
     {
       "label": "Download database",
       "type": "shell",
-      "command": "uv run pipelines/run.py run download_database",
+      "command": "uv run pipelines/run.py run download_database_https --env prod",
       "group": "none",
       "icon": {
         "id": "cloud-download"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,19 +2,6 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Build database",
-      "type": "shell",
-      "command": "uv run pipelines/run.py run build_database",
-      "group": "none",
-      "icon": {
-        "id": "database"
-      },
-      "presentation": {
-        "reveal": "always",
-        "panel": "new"
-      }
-    },
-    {
       "label": "Run Evidence",
       "type": "shell",
       "command": "if command -v npm > /dev/null 2>&1; then cd analytics/evidence && npm install && npm run sources && npm run dev -- --host 0.0.0.0; else echo 'NPM not installed'; fi",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -30,6 +30,19 @@
         "reveal": "always",
         "panel": "new"
       }
+    },
+    {
+      "label": "Download database",
+      "type": "shell",
+      "command": "uv run pipelines/run.py run download_database",
+      "group": "none",
+      "icon": {
+        "id": "cloud-download"
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
     }
-  ]
+  ],
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,19 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "Download database",
+      "type": "shell",
+      "command": "uv run pipelines/run.py run download_database_https --env prod",
+      "group": "none",
+      "icon": {
+        "id": "cloud-download"
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    },
+    {
       "label": "Run Evidence",
       "type": "shell",
       "command": "if command -v npm > /dev/null 2>&1; then cd analytics/evidence && npm install && npm run sources && npm run dev -- --host 0.0.0.0; else echo 'NPM not installed'; fi",
@@ -18,18 +31,5 @@
         "panel": "new"
       }
     },
-    {
-      "label": "Download database",
-      "type": "shell",
-      "command": "uv run pipelines/run.py run download_database_https --env prod",
-      "group": "none",
-      "icon": {
-        "id": "cloud-download"
-      },
-      "presentation": {
-        "reveal": "always",
-        "panel": "new"
-      }
-    }
   ],
 }


### PR DESCRIPTION
**Contexte** : depuis que la pull request #27 a été fusionnée, il est désormais conseillé de télécharger la base de données plutôt que de la construire avec le pipeline de l'équipe des data engineers.

**Solution** : 
- ajouter une tâche "Download database" dans VS Code, permettant d'avoir un raccourci dans la _status bar_ en bas de l'écran
- supprimer la tâche "Build database"

**Résultat** : voilà ci-dessous une copie d'écran pour montrer à quoi ressemblerait la _status bar_ après cette _pull request_.

![image](https://github.com/user-attachments/assets/d1cb2b8a-d4bc-4682-8775-09321681d8a7)
