### PR TITLE
Feature: Add a github action to deploy dbt docs on a github page

### DIFF
--- a/.github/workflows/deploy_dbt_docs_to_github_page.yml
+++ b/.github/workflows/deploy_dbt_docs_to_github_page.yml
@@ -1,0 +1,70 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy dbt docs to github Pages
+
+on:
+  # Runs on pushes targeting the default branch when file is modified in the dbt_ project.
+  push:
+    branches: [ "main" ]
+    paths: [ "dbt_/**" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Raison de la synchronisation'
+        required: true
+        type: string
+        default: 'Mise à jour manuelle de la page dbt docs'
+
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install a specific version of uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: ">=0.4.0"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Download production database from Storage
+        run: |
+          uv run pipelines/run.py run download_database_https
+
+      - name: dbt deps & dbt docs generate
+        run: cd dbt_/ && uv run dbt deps && uv run dbt docs generate
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload dbt_/target repository
+          path: 'dbt_/target'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
I was experimenting with a way to push dbt docs to a Github page:

Process:
- Runs when a file is changed in the `dbt_/` folder (or manually triggered)
- Installs uv
- Fetch the duckdb database (from https because I had no S3 credentials on my fork, we could use the S3 download)
- run dbt deps and docs generate
- docs generate creates the files for the documentation interface in the `./target` folder
- Github page can read the html files created by docs generate
- Upload the target folder to the page

It works on my fork (the branch is the same as main). 
Github page: https://moreaupascal56.github.io/13_pollution_eau/#!/overview
Job: https://github.com/moreaupascal56/13_pollution_eau/actions/runs/13308226810

Would love to hear your opinions. 

It is also possible to do something like this:
- https://medium.com/@connormcshane/how-to-deploy-dbt-docs-to-github-pages-using-github-actions-4f1774680155
- https://medium.com/dbt-local-taiwan/host-dbt-documentation-site-with-github-pages-in-5-minutes-7b80e8b62feb

But it adds more code and as we are using duckdb we can use the solution I propose.
We would also run dbt tests quite easily thanks to duckdb (and because the db is public). 

The action is based on the Static HTML Github action template

