### PR TITLE
Fix: changement des valeurs acceptables pour `plvconformitereferencechim` dans dbt

### DIFF
--- a/dbt_/models/staging/edc/_edc__models.yml
+++ b/dbt_/models/staging/edc/_edc__models.yml
@@ -275,10 +275,14 @@ models:
             - C : conforme
             - N : non conforme
             - S : sans objet lorsqu'aucun paramètre microbio n'a été mesuré.
+            - D : conforme dans le cadre d’une dérogation
+          
+          N.B. cette dernière valeur n'est pas possible selon la documentation officielle d'EDC, mais on trouve des prélèvements
+          avec cette valeur. A discuter.
         type: VARCHAR(1)
         tests:
           - accepted_values:
-              values: ["blanc", "C", "N", "S"]
+              values: ["blanc", "C", "N", "S", "D"]
       
       
   


### PR DESCRIPTION
**Contexte** : la commande `uv run dbt build` retourne l'erreur `Failure in test accepted_values_stg_edc__prevelevements_plvconformitereferencechim__blanc__C__N__S (models/staging/edc/_edc__models.yml`

**Solution** : discuté plus longuement sur Slack. On est parti du principe qu'on changeait juste le modèle dans dbt pour accepter la valeur "D" pour la variable `plvconformitereferencechim`. On voit ce que cela a comme conséquence du point de vue "métier" dans une discussion sur le canal général.