### PR TITLE
Add metabase docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:19-buster
+
+ENV MB_PLUGINS_DIR=/home/plugins/
+
+ADD https://downloads.metabase.com/v0.52.4/metabase.jar /home
+ADD https://github.com/MotherDuck-Open-Source/metabase_duckdb_driver/releases/download/0.2.12/duckdb.metabase-driver.jar /home/plugins/
+
+RUN chmod 744 /home/plugins/duckdb.metabase-driver.jar
+
+CMD ["java", "-jar", "/home/metabase.jar"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  metabase:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./database:/database
+      - metabase-data:/metabase-data
+    environment:
+      - MB_DB_FILE=/metabase-data/metabase.db
+      - MB_PLUGINS_DIR=/home/plugins
+      - DUCKDB_FILE=/database/data.duckdb
+    restart: unless-stopped
+
+volumes:
+  metabase-data:

--- a/pipelines/tasks/download_database_https.py
+++ b/pipelines/tasks/download_database_https.py
@@ -10,10 +10,12 @@ Examples:
 """
 
 import logging
+import os
 
 from pipelines.config.config import get_s3_path
 from pipelines.tasks._common import DUCKDB_FILE
 from pipelines.utils.storage_client import ObjectStorageClient
+
 from ._common import download_file_from_https
 
 logger = logging.getLogger(__name__)
@@ -28,7 +30,12 @@ def download_database_from_https(env):
     url = f"https://{s3.bucket_name}.{s3.endpoint_url.split('https://')[1]}/{get_s3_path(env)}"
     local_db_path = DUCKDB_FILE
 
+    os.makedirs(os.path.dirname(local_db_path), exist_ok=True)
+
     download_file_from_https(url=url, filepath=local_db_path)
+
+    os.chmod(local_db_path, 0o644)
+
     logger.info(f"✅ Base téléchargée depuis s3 via HTTPS: {url} -> {local_db_path}")
 
 


### PR DESCRIPTION
Metabase image have been added in order to visualize data more easily. 

In order to run the docker image you should follow theses steps :
1. Download database using `uv run ./pipelines/download_database_https.py`
2. Run `docker compose build` and `docker compose up` -d 
3. In metabase, select the connection **DuckDB** and indicate the path **/database/data.duckdb**