### PR TITLE
update pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: mixed-line-ending


### PR DESCRIPTION
bugfix: warning of uv run pre-commit run --all-files
run the command which updated the pre-commit version from4.3.0 to 5.0.0: pre-commit autoupdate --repo https://github.com/pre-commit/pre-commit-hooks